### PR TITLE
Add ERP domain layer package with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.eggs/
+.installed.cfg
+.pytest_cache/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,84 @@
-# ERP
+# ERP Domain Layer
+
+This repository contains a lightweight, framework-agnostic domain layer for an
+Enterprise Resource Planning (ERP) style system. The goal of the project is to
+provide a clear, well-structured codebase that demonstrates how to manage
+inventory, orders, and invoices using plain Python objects.
+
+## Project layout
+
+```
+.
+├── pyproject.toml          # Packaging and tooling configuration
+├── src/
+│   └── erp/
+│       ├── __init__.py     # Convenience exports
+│       ├── accounting.py   # Invoice management helpers
+│       ├── inventory.py    # Product and stock management
+│       ├── models.py       # Core domain models
+│       └── orders.py       # Order lifecycle management
+└── tests/                  # Automated test suite using pytest
+```
+
+## Getting started
+
+Create and activate a virtual environment, then install the package in editable
+mode along with the testing tools:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+pip install pytest
+```
+
+> The project intentionally avoids runtime dependencies to remain lightweight.
+
+## Running the test suite
+
+The repository includes a pytest-based test suite that exercises the main
+behaviour of the domain layer. After installing the dependencies, run:
+
+```bash
+pytest
+```
+
+All tests should pass and provide a quick verification that the core flows work
+as expected.
+
+## Usage example
+
+```python
+from decimal import Decimal
+
+from erp import Customer, InventoryManager, InvoiceManager, OrderManager
+
+inventory = InventoryManager()
+inventory.register_product("SKU-1", "Widget", Decimal("12.50"), initial_stock=10)
+
+customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+orders = OrderManager(inventory)
+order = orders.create_order("ORD-1", customer, [("SKU-1", 3)])
+orders.fulfill_order(order.order_id)
+
+invoices = InvoiceManager()
+invoice = invoices.create_from_order("INV-1", order)
+invoices.issue(invoice.invoice_id)
+```
+
+This snippet demonstrates the main lifecycle: registering a product, creating
+an order that reserves stock, and generating an invoice once the order is ready
+for billing.
+
+## Contributing
+
+Issues and pull requests are welcome. When contributing, please ensure that:
+
+1. Code remains free of unnecessary dependencies.
+2. Tests cover new functionality and continue to pass.
+3. Documentation is updated for new features or behavioural changes.
+
+## License
+
+This project is released under the MIT License. See `LICENSE` if provided by
+upstream consumers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "erp"
+version = "0.1.0"
+description = "Domain layer for a lightweight ERP demo application"
+authors = [{name = "ERP Maintainers"}]
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/erp/__init__.py
+++ b/src/erp/__init__.py
@@ -1,0 +1,22 @@
+"""Lightweight ERP domain layer utilities.
+
+This package provides building blocks for working with products, orders, and
+invoices in a small enterprise resource planning context. The implementation is
+intentionally simple and uses in-memory storage to remain framework agnostic.
+"""
+
+from .accounting import InvoiceManager
+from .inventory import InventoryManager
+from .models import Customer, InvoiceStatus, Order, OrderStatus, Product
+from .orders import OrderManager
+
+__all__ = [
+    "Customer",
+    "InvoiceManager",
+    "InvoiceStatus",
+    "InventoryManager",
+    "Order",
+    "OrderManager",
+    "OrderStatus",
+    "Product",
+]

--- a/src/erp/accounting.py
+++ b/src/erp/accounting.py
@@ -1,0 +1,62 @@
+"""Accounting helpers."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Dict
+
+from .models import Invoice, InvoiceLine, InvoiceStatus, Order
+
+
+class InvoiceManager:
+    """Generates invoices from orders and tracks their payment status."""
+
+    def __init__(self) -> None:
+        self._invoices: Dict[str, Invoice] = {}
+
+    def create_from_order(self, invoice_id: str, order: Order) -> Invoice:
+        if invoice_id in self._invoices:
+            raise ValueError(f"Invoice with id {invoice_id} already exists.")
+        if not order.lines:
+            raise ValueError("Cannot create an invoice for an order without lines.")
+
+        lines = [
+            InvoiceLine(
+                description=line.product.name,
+                quantity=line.quantity,
+                unit_price=line.product.unit_price,
+            )
+            for line in order.lines
+        ]
+        invoice = Invoice(invoice_id=invoice_id, order=order, lines=tuple(lines))
+        self._invoices[invoice_id] = invoice
+        return invoice
+
+    def issue(self, invoice_id: str) -> Invoice:
+        invoice = self._get_invoice(invoice_id)
+        invoice.issue()
+        return invoice
+
+    def register_payment(self, invoice_id: str) -> Invoice:
+        invoice = self._get_invoice(invoice_id)
+        invoice.register_payment()
+        return invoice
+
+    def outstanding_balance(self) -> Decimal:
+        return sum(
+            (
+                invoice.total()
+                for invoice in self._invoices.values()
+                if invoice.status is not InvoiceStatus.PAID
+            ),
+            Decimal("0"),
+        )
+
+    def _get_invoice(self, invoice_id: str) -> Invoice:
+        try:
+            return self._invoices[invoice_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown invoice with id {invoice_id}.") from exc
+
+
+__all__ = ["InvoiceManager"]

--- a/src/erp/inventory.py
+++ b/src/erp/inventory.py
@@ -1,0 +1,82 @@
+"""Inventory management helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, List
+
+from .models import Product
+
+
+@dataclass(slots=True)
+class InventorySnapshot:
+    """Lightweight representation of a product's availability."""
+
+    sku: str
+    name: str
+    unit_price: Decimal
+    stock: int
+
+
+class InventoryManager:
+    """Tracks products and their availability."""
+
+    def __init__(self) -> None:
+        self._products: Dict[str, Product] = {}
+
+    def register_product(
+        self, sku: str, name: str, unit_price: Decimal, *, initial_stock: int = 0
+    ) -> Product:
+        if sku in self._products:
+            raise ValueError(f"Product with SKU {sku} already registered.")
+        product = Product(sku=sku, name=name, unit_price=Decimal(unit_price), stock=0)
+        if initial_stock:
+            product.restock(initial_stock)
+        self._products[sku] = product
+        return product
+
+    def get_product(self, sku: str) -> Product:
+        try:
+            return self._products[sku]
+        except KeyError as exc:
+            raise KeyError(f"Unknown product with SKU {sku}.") from exc
+
+    def restock(self, sku: str, quantity: int) -> None:
+        product = self.get_product(sku)
+        product.restock(quantity)
+
+    def allocate(self, sku: str, quantity: int) -> None:
+        product = self.get_product(sku)
+        product.allocate(quantity)
+
+    def release(self, sku: str, quantity: int) -> None:
+        product = self.get_product(sku)
+        product.release(quantity)
+
+    def list_products(self) -> Iterable[InventorySnapshot]:
+        for product in self._products.values():
+            yield InventorySnapshot(
+                sku=product.sku,
+                name=product.name,
+                unit_price=product.unit_price,
+                stock=product.stock,
+            )
+
+    def low_stock(self, *, threshold: int) -> List[InventorySnapshot]:
+        if threshold < 0:
+            raise ValueError("Threshold must be non-negative.")
+        return [
+            snapshot
+            for snapshot in self.list_products()
+            if snapshot.stock <= threshold
+        ]
+
+    def available_quantity(self, sku: str) -> int:
+        return self.get_product(sku).stock
+
+    def clear(self) -> None:
+        self._products.clear()
+
+
+__all__ = ["InventoryManager", "InventorySnapshot"]

--- a/src/erp/models.py
+++ b/src/erp/models.py
@@ -1,0 +1,162 @@
+"""Domain models used by the ERP package."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from typing import Iterable, List
+
+
+class OrderStatus(str, Enum):
+    """Possible states for an :class:`Order`."""
+
+    PENDING = "pending"
+    CANCELLED = "cancelled"
+    FULFILLED = "fulfilled"
+
+
+class InvoiceStatus(str, Enum):
+    """Possible states for an :class:`Invoice`."""
+
+    DRAFT = "draft"
+    ISSUED = "issued"
+    PAID = "paid"
+
+
+@dataclass(slots=True)
+class Product:
+    """Represents a product that can be stocked and sold."""
+
+    sku: str
+    name: str
+    unit_price: Decimal
+    stock: int = 0
+
+    def restock(self, quantity: int) -> None:
+        """Increase the available inventory for the product."""
+
+        if quantity <= 0:
+            raise ValueError("Quantity to restock must be greater than zero.")
+        self.stock += quantity
+
+    def allocate(self, quantity: int) -> None:
+        """Allocate stock for a sale, reducing the available inventory."""
+
+        if quantity <= 0:
+            raise ValueError("Quantity to allocate must be greater than zero.")
+        if quantity > self.stock:
+            raise ValueError(
+                f"Cannot allocate {quantity} units of {self.sku}; only {self.stock} remaining."
+            )
+        self.stock -= quantity
+
+    def release(self, quantity: int) -> None:
+        """Return reserved stock back to the inventory."""
+
+        if quantity <= 0:
+            raise ValueError("Quantity to release must be greater than zero.")
+        self.stock += quantity
+
+
+@dataclass(slots=True)
+class Customer:
+    """Represents a customer that can place orders."""
+
+    customer_id: str
+    name: str
+    email: str
+
+
+@dataclass(slots=True)
+class OrderLine:
+    """Represents a single line inside an order."""
+
+    product: Product
+    quantity: int
+
+    @property
+    def total(self) -> Decimal:
+        return self.product.unit_price * self.quantity
+
+
+@dataclass(slots=True)
+class Order:
+    """Represents a customer order comprised of multiple order lines."""
+
+    order_id: str
+    customer: Customer
+    lines: List[OrderLine] = field(default_factory=list)
+    status: OrderStatus = OrderStatus.PENDING
+    created_on: date = field(default_factory=date.today)
+
+    def total(self) -> Decimal:
+        return sum((line.total for line in self.lines), Decimal("0"))
+
+    def add_line(self, product: Product, quantity: int) -> None:
+        if quantity <= 0:
+            raise ValueError("Order line quantity must be greater than zero.")
+        self.lines.append(OrderLine(product=product, quantity=quantity))
+
+    def cancel(self) -> None:
+        if self.status is OrderStatus.FULFILLED:
+            raise ValueError("Fulfilled orders cannot be cancelled.")
+        self.status = OrderStatus.CANCELLED
+
+    def fulfill(self) -> None:
+        if self.status is OrderStatus.CANCELLED:
+            raise ValueError("Cancelled orders cannot be fulfilled.")
+        self.status = OrderStatus.FULFILLED
+
+
+@dataclass(slots=True)
+class InvoiceLine:
+    """Represents the monetary amount of a single order line."""
+
+    description: str
+    quantity: int
+    unit_price: Decimal
+
+    @property
+    def total(self) -> Decimal:
+        return self.unit_price * self.quantity
+
+
+@dataclass(slots=True)
+class Invoice:
+    """Represents a billing document generated from an order."""
+
+    invoice_id: str
+    order: Order
+    lines: Iterable[InvoiceLine]
+    status: InvoiceStatus = InvoiceStatus.DRAFT
+    issued_on: date | None = None
+    paid_on: date | None = None
+
+    def total(self) -> Decimal:
+        return sum((line.total for line in self.lines), Decimal("0"))
+
+    def issue(self, issued_on: date | None = None) -> None:
+        if self.status is not InvoiceStatus.DRAFT:
+            raise ValueError("Only draft invoices can be issued.")
+        self.status = InvoiceStatus.ISSUED
+        self.issued_on = issued_on or date.today()
+
+    def register_payment(self, paid_on: date | None = None) -> None:
+        if self.status is not InvoiceStatus.ISSUED:
+            raise ValueError("Only issued invoices can be marked as paid.")
+        self.status = InvoiceStatus.PAID
+        self.paid_on = paid_on or date.today()
+
+
+__all__ = [
+    "Customer",
+    "Invoice",
+    "InvoiceLine",
+    "InvoiceStatus",
+    "Order",
+    "OrderLine",
+    "OrderStatus",
+    "Product",
+]

--- a/src/erp/orders.py
+++ b/src/erp/orders.py
@@ -1,0 +1,74 @@
+"""Order management helpers."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Sequence
+
+from .inventory import InventoryManager
+from .models import Customer, Order, OrderStatus, Product
+
+
+class OrderManager:
+    """Coordinates stock reservations and order lifecycles."""
+
+    def __init__(self, inventory: InventoryManager) -> None:
+        self._inventory = inventory
+        self._orders: Dict[str, Order] = {}
+
+    def create_order(
+        self,
+        order_id: str,
+        customer: Customer,
+        line_requests: Sequence[tuple[str, int]],
+    ) -> Order:
+        if order_id in self._orders:
+            raise ValueError(f"Order with id {order_id} already exists.")
+        if not line_requests:
+            raise ValueError("Orders must contain at least one line item.")
+
+        order = Order(order_id=order_id, customer=customer)
+
+        reservations: list[tuple[Product, int]] = []
+        try:
+            for sku, quantity in line_requests:
+                product = self._inventory.get_product(sku)
+                self._inventory.allocate(sku, quantity)
+                reservations.append((product, quantity))
+                order.add_line(product, quantity)
+        except Exception:
+            for product, quantity in reservations:
+                product.release(quantity)
+            raise
+
+        self._orders[order_id] = order
+        return order
+
+    def cancel_order(self, order_id: str) -> Order:
+        order = self._get_order(order_id)
+        if order.status is OrderStatus.CANCELLED:
+            return order
+        if order.status is OrderStatus.FULFILLED:
+            raise ValueError("Fulfilled orders cannot be cancelled.")
+        for line in order.lines:
+            self._inventory.release(line.product.sku, line.quantity)
+        order.cancel()
+        return order
+
+    def fulfill_order(self, order_id: str) -> Order:
+        order = self._get_order(order_id)
+        if order.status is OrderStatus.CANCELLED:
+            raise ValueError("Cancelled orders cannot be fulfilled.")
+        order.fulfill()
+        return order
+
+    def list_orders(self) -> Iterable[Order]:
+        return list(self._orders.values())
+
+    def _get_order(self, order_id: str) -> Order:
+        try:
+            return self._orders[order_id]
+        except KeyError as exc:
+            raise KeyError(f"Unknown order with id {order_id}.") from exc
+
+
+__all__ = ["OrderManager"]

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+
+import pytest
+
+from erp.accounting import InvoiceManager
+from erp.inventory import InventoryManager
+from erp.models import Customer
+from erp.orders import OrderManager
+
+
+@pytest.fixture
+def order():
+    inventory = InventoryManager()
+    inventory.register_product("SKU-1", "Widget", Decimal("5.00"), initial_stock=5)
+
+    order_manager = OrderManager(inventory)
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    return order_manager.create_order("ORD-1", customer, [("SKU-1", 2)])
+
+
+def test_invoice_totals_match_order(order):
+    invoices = InvoiceManager()
+
+    invoice = invoices.create_from_order("INV-1", order)
+
+    assert invoice.total() == Decimal("10.00")
+
+
+def test_invoice_must_have_unique_id(order):
+    invoices = InvoiceManager()
+    invoices.create_from_order("INV-1", order)
+
+    with pytest.raises(ValueError):
+        invoices.create_from_order("INV-1", order)
+
+
+def test_invoice_lifecycle(order):
+    invoices = InvoiceManager()
+    invoice = invoices.create_from_order("INV-1", order)
+
+    invoices.issue("INV-1")
+    assert invoice.status.name.lower() == "issued"
+
+    invoices.register_payment("INV-1")
+    assert invoice.status.name.lower() == "paid"
+
+
+def test_outstanding_balance_ignores_paid_invoices(order):
+    invoices = InvoiceManager()
+    invoice = invoices.create_from_order("INV-1", order)
+
+    assert invoices.outstanding_balance() == invoice.total()
+
+    invoices.issue("INV-1")
+    invoices.register_payment("INV-1")
+
+    assert invoices.outstanding_balance() == Decimal("0")

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,0 +1,48 @@
+from decimal import Decimal
+
+import pytest
+
+from erp.inventory import InventoryManager
+
+
+def test_register_and_retrieve_product():
+    inventory = InventoryManager()
+    created = inventory.register_product("SKU-1", "Test Product", Decimal("12.50"))
+
+    retrieved = inventory.get_product("SKU-1")
+
+    assert retrieved is created
+    assert retrieved.stock == 0
+
+
+def test_restock_and_allocate_updates_stock_levels():
+    inventory = InventoryManager()
+    inventory.register_product("SKU-1", "Widget", Decimal("5.00"), initial_stock=5)
+
+    inventory.restock("SKU-1", 5)
+    assert inventory.available_quantity("SKU-1") == 10
+
+    inventory.allocate("SKU-1", 4)
+    assert inventory.available_quantity("SKU-1") == 6
+
+    inventory.release("SKU-1", 3)
+    assert inventory.available_quantity("SKU-1") == 9
+
+
+def test_allocate_more_than_available_raises_error():
+    inventory = InventoryManager()
+    inventory.register_product("SKU-1", "Widget", Decimal("5.00"))
+
+    with pytest.raises(ValueError):
+        inventory.allocate("SKU-1", 1)
+
+
+def test_low_stock_filters_based_on_threshold():
+    inventory = InventoryManager()
+    inventory.register_product("SKU-1", "Widget", Decimal("5.00"), initial_stock=2)
+    inventory.register_product("SKU-2", "Gadget", Decimal("8.00"), initial_stock=10)
+
+    low_stock = inventory.low_stock(threshold=3)
+
+    assert len(low_stock) == 1
+    assert low_stock[0].sku == "SKU-1"

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,72 @@
+from decimal import Decimal
+
+import pytest
+
+from erp.inventory import InventoryManager
+from erp.models import Customer
+from erp.orders import OrderManager
+
+
+@pytest.fixture
+def inventory():
+    manager = InventoryManager()
+    manager.register_product("SKU-1", "Widget", Decimal("5.00"), initial_stock=5)
+    manager.register_product("SKU-2", "Gadget", Decimal("9.50"), initial_stock=10)
+    return manager
+
+
+def test_create_order_reserves_stock(inventory):
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    manager = OrderManager(inventory)
+
+    order = manager.create_order(
+        "ORD-1",
+        customer,
+        [("SKU-1", 2), ("SKU-2", 3)],
+    )
+
+    assert order.total() == Decimal("5.00") * 2 + Decimal("9.50") * 3
+    assert inventory.available_quantity("SKU-1") == 3
+    assert inventory.available_quantity("SKU-2") == 7
+
+
+def test_cancel_order_releases_stock(inventory):
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    manager = OrderManager(inventory)
+
+    manager.create_order("ORD-1", customer, [("SKU-1", 2)])
+    manager.cancel_order("ORD-1")
+
+    assert inventory.available_quantity("SKU-1") == 5
+
+
+def test_fulfilled_order_cannot_be_cancelled(inventory):
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    manager = OrderManager(inventory)
+
+    manager.create_order("ORD-1", customer, [("SKU-1", 2)])
+    manager.fulfill_order("ORD-1")
+
+    with pytest.raises(ValueError):
+        manager.cancel_order("ORD-1")
+
+
+def test_cannot_fulfill_cancelled_order(inventory):
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    manager = OrderManager(inventory)
+
+    manager.create_order("ORD-1", customer, [("SKU-1", 2)])
+    manager.cancel_order("ORD-1")
+
+    with pytest.raises(ValueError):
+        manager.fulfill_order("ORD-1")
+
+
+def test_duplicate_order_id_rejected(inventory):
+    customer = Customer(customer_id="C-1", name="Alice", email="alice@example.com")
+    manager = OrderManager(inventory)
+
+    manager.create_order("ORD-1", customer, [("SKU-1", 2)])
+
+    with pytest.raises(ValueError):
+        manager.create_order("ORD-1", customer, [("SKU-1", 1)])


### PR DESCRIPTION
## Summary
- add an organised ERP domain package covering inventory, ordering, and invoicing
- configure packaging metadata, ignores, and documentation for the repository structure
- provide pytest-based coverage for core workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfa134519c832c83ce061de272b1fb